### PR TITLE
fix: be explicit about which id in sql

### DIFF
--- a/src/repositories/reviewsRepo.js
+++ b/src/repositories/reviewsRepo.js
@@ -87,7 +87,7 @@ class ReviewsRepo {
   }
 
   async getAllReviewsOfOneMovie(movieId) {
-    const ALL_REVIEWS_OF_ONE_MOVIE = `SELECT * FROM ${this.table} JOIN movies ON movies.id = ${this.table}.movie_id WHERE movies.id = $1`;
+    const ALL_REVIEWS_OF_ONE_MOVIE = `SELECT ${this.table}.*, movie_title FROM ${this.table} JOIN movies ON movies.id = ${this.table}.movie_id WHERE movies.id = $1`;
 
     const result = await this.client.dbQuery(ALL_REVIEWS_OF_ONE_MOVIE, movieId);
 

--- a/tests/getAllReviews.test.js
+++ b/tests/getAllReviews.test.js
@@ -88,7 +88,7 @@ describe('get all reviews', () => {
 
     test('then: we return all the reviews of that one movie', async () => {
       expect(mockPgClient.dbQuery).toHaveBeenCalledWith(
-        'SELECT * FROM reviews JOIN movies ON movies.id = reviews.movie_id WHERE movies.id = $1',
+        'SELECT reviews.*, movie_title FROM reviews JOIN movies ON movies.id = reviews.movie_id WHERE movies.id = $1',
         movieId.toString(),
       );
 


### PR DESCRIPTION
# Description

Before Postgres was returning the movie id as `id`. Consequently, we were sometimes looking for reviews with the wrong id. Now, we're being explicit in the SQL. The only movie attribute we return with this SQL is `movie_title`, much like the other SQL queries in the `reviewsRepo`.

Also, I updated the test to ensure this bug 🐛 doesn't rear its ugly head again.

## Ticket ref

Jira-4042